### PR TITLE
JSON-RPC v1.0 responses

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>simple-json-rpc</artifactId>
         <groupId>com.github.arteam</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.001-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/ClassMetadata.java
+++ b/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/ClassMetadata.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Date: 8/1/14
@@ -13,6 +14,53 @@ import java.util.Map;
  * <p>
  * Metadata about a Java class
  */
-public record ClassMetadata(@Nullable ParamsType paramsType, IdGenerator<?> idGenerator,
-                            Map<Method, MethodMetadata> methods) {
+public class ClassMetadata {
+    private @Nullable ParamsType paramsType;
+    private IdGenerator<?> idGenerator;
+    private Map<Method, MethodMetadata> methods;
+
+    public ClassMetadata(){}
+
+    public ClassMetadata(@Nullable ParamsType paramsType, IdGenerator<?> idGenerator,
+                         Map<Method, MethodMetadata> methods) {
+        this.paramsType = paramsType;
+        this.idGenerator = idGenerator;
+        this.methods = methods;
+    }
+
+    public @Nullable ParamsType paramsType() {
+        return paramsType;
+    }
+
+    public IdGenerator<?> idGenerator() {
+        return idGenerator;
+    }
+
+    public Map<Method, MethodMetadata> methods() {
+        return methods;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ClassMetadata that = (ClassMetadata) obj;
+        return Objects.equals(this.paramsType, that.paramsType) &&
+                Objects.equals(this.idGenerator, that.idGenerator) &&
+                Objects.equals(this.methods, that.methods);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paramsType, idGenerator, methods);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassMetadata[" +
+                "paramsType=" + paramsType + ", " +
+                "idGenerator=" + idGenerator + ", " +
+                "methods=" + methods + ']';
+    }
+
 }

--- a/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/MethodMetadata.java
+++ b/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/MethodMetadata.java
@@ -4,6 +4,7 @@ import com.github.arteam.simplejsonrpc.client.ParamsType;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Date: 8/1/14
@@ -11,7 +12,54 @@ import java.util.Map;
  * <p>
  * Metadata about a Java method
  */
-public record MethodMetadata(String name,
-                             @Nullable ParamsType paramsType,
-                             Map<String, ParameterMetadata> params) {
+public class MethodMetadata {
+    final private String name;
+    final private @Nullable ParamsType paramsType;
+    final private Map<String, ParameterMetadata> params;
+
+//    public MethodMetadata(){}
+
+    public MethodMetadata(String name,
+                          @Nullable ParamsType paramsType,
+                          Map<String, ParameterMetadata> params) {
+        this.name = name;
+        this.paramsType = paramsType;
+        this.params = params;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public @Nullable ParamsType paramsType() {
+        return paramsType;
+    }
+
+    public Map<String, ParameterMetadata> params() {
+        return params;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        MethodMetadata that = (MethodMetadata) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.paramsType, that.paramsType) &&
+                Objects.equals(this.params, that.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, paramsType, params);
+    }
+
+    @Override
+    public String toString() {
+        return "MethodMetadata[" +
+                "name=" + name + ", " +
+                "paramsType=" + paramsType + ", " +
+                "params=" + params + ']';
+    }
+
 }

--- a/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/ParameterMetadata.java
+++ b/client/src/main/java/com/github/arteam/simplejsonrpc/client/metadata/ParameterMetadata.java
@@ -1,12 +1,24 @@
 package com.github.arteam.simplejsonrpc.client.metadata;
 
+import java.util.Objects;
+
 /**
  * Date: 8/1/14
  * Time: 7:44 PM
  * <p>
  * Method parameter metadata
  */
-public record ParameterMetadata(int index, boolean optional) {
+public final class ParameterMetadata {
+    private final int index;
+    private final boolean optional;
+
+    /**
+     *
+     */
+    public ParameterMetadata(int index, boolean optional) {
+        this.index = index;
+        this.optional = optional;
+    }
 
     public int getIndex() {
         return index;
@@ -15,4 +27,34 @@ public record ParameterMetadata(int index, boolean optional) {
     public boolean isOptional() {
         return optional;
     }
+
+    public int index() {
+        return index;
+    }
+
+    public boolean optional() {
+        return optional;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ParameterMetadata that = (ParameterMetadata) obj;
+        return this.index == that.index &&
+                this.optional == that.optional;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, optional);
+    }
+
+    @Override
+    public String toString() {
+        return "ParameterMetadata[" +
+                "index=" + index + ", " +
+                "optional=" + optional + ']';
+    }
+
 }

--- a/client/src/test/java/com/github/arteam/simplejsonrpc/client/JsonRpcClientErrorsTest.java
+++ b/client/src/test/java/com/github/arteam/simplejsonrpc/client/JsonRpcClientErrorsTest.java
@@ -16,9 +16,7 @@ public class JsonRpcClientErrorsTest {
 
     private JsonRpcClient client = new JsonRpcClient(request -> {
         System.out.println(request);
-        return """
-                {"jsonrpc": "2.0", "id": 1001, "result": true}
-                """;
+        return "{\"jsonrpc\": \"2.0\", \"id\": 1001, \"result\": true}";
     });
 
     @Test
@@ -80,9 +78,7 @@ public class JsonRpcClientErrorsTest {
     public void testResultAndErrorAreNotSet() {
         JsonRpcClient client = new JsonRpcClient(request -> {
             System.out.println(request);
-            return """
-                    {"jsonrpc": "2.0", "id": 1001}
-                    """;
+            return "{\"jsonrpc\": \"2.0\", \"id\": 1001}";
         });
         assertThatIllegalStateException().isThrownBy(() -> client.createRequest()
                 .method("update")
@@ -105,9 +101,7 @@ public class JsonRpcClientErrorsTest {
     public void testExpectedNotNull() {
         JsonRpcClient client = new JsonRpcClient(request -> {
             System.out.println(request);
-            return """
-                    {"jsonrpc": "2.0", "result" : null, "id": 1001}
-                    """;
+            return "{\"jsonrpc\": \"2.0\", \"result\" : null, \"id\": 1001}";
         });
         assertThatIllegalStateException().isThrownBy(() -> client.createRequest()
                 .method("getPlayer")

--- a/client/src/test/java/com/github/arteam/simplejsonrpc/client/JsonRpcClientTest.java
+++ b/client/src/test/java/com/github/arteam/simplejsonrpc/client/JsonRpcClientTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,7 +115,7 @@ public class JsonRpcClientTest extends BaseClientTest {
                 .execute();
         assertThat(players).isNotNull();
         assertThat(players).hasSize(3);
-        List<String> lastNames = players.stream().map(Player::lastName).toList();
+        List<String> lastNames = players.stream().map(Player::lastName).collect(Collectors.toList());
         assertThat(lastNames).containsOnly("Allen", "Stamkos", "Hedman");
     }
 

--- a/client/src/test/java/com/github/arteam/simplejsonrpc/client/domain/Player.java
+++ b/client/src/test/java/com/github/arteam/simplejsonrpc/client/domain/Player.java
@@ -1,9 +1,98 @@
 package com.github.arteam.simplejsonrpc.client.domain;
 
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record Player(String firstName, String lastName,
-                     Team team, int number,
-                     Position position, Date birthDate,
-                     double capHit) {
+import java.util.Date;
+import java.util.Objects;
+
+public class Player {
+    private String firstName;
+    private String lastName;
+    private Team team;
+    private int number;
+    private Position position;
+    private Date birthDate;
+    private double capHit;
+
+    public Player(){}
+
+    public Player(String firstName, String lastName,
+                  Team team, int number,
+                  Position position, Date birthDate,
+                  double capHit) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.team = team;
+        this.number = number;
+        this.position = position;
+        this.birthDate = birthDate;
+        this.capHit = capHit;
+    }
+
+    @JsonProperty("firstName")
+    public String firstName() {
+        return firstName;
+    }
+
+    @JsonProperty("lastName")
+    public String lastName() {
+        return lastName;
+    }
+
+    @JsonProperty("team")
+    public Team team() {
+        return team;
+    }
+
+    @JsonProperty("number")
+    public int number() {
+        return number;
+    }
+
+    @JsonProperty("position")
+    public Position position() {
+        return position;
+    }
+
+    @JsonProperty("birthDate")
+    public Date birthDate() {
+        return birthDate;
+    }
+
+    @JsonProperty("capHit")
+    public double capHit() {
+        return capHit;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Player) obj;
+        return Objects.equals(this.firstName, that.firstName) &&
+                Objects.equals(this.lastName, that.lastName) &&
+                Objects.equals(this.team, that.team) &&
+                this.number == that.number &&
+                Objects.equals(this.position, that.position) &&
+                Objects.equals(this.birthDate, that.birthDate) &&
+                Double.doubleToLongBits(this.capHit) == Double.doubleToLongBits(that.capHit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, team, number, position, birthDate, capHit);
+    }
+
+    @Override
+    public String toString() {
+        return "Player[" +
+                "firstName=" + firstName + ", " +
+                "lastName=" + lastName + ", " +
+                "team=" + team + ", " +
+                "number=" + number + ", " +
+                "position=" + position + ", " +
+                "birthDate=" + birthDate + ", " +
+                "capHit=" + capHit + ']';
+    }
+
 }

--- a/client/src/test/java/com/github/arteam/simplejsonrpc/client/domain/Team.java
+++ b/client/src/test/java/com/github/arteam/simplejsonrpc/client/domain/Team.java
@@ -1,4 +1,49 @@
 package com.github.arteam.simplejsonrpc.client.domain;
 
-public record Team(String name, String league) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class Team {
+    private String name;
+    private String league;
+
+    public Team(){}
+
+    public Team(String name, String league) {
+        this.name = name;
+        this.league = league;
+    }
+
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    @JsonProperty
+    public String league() {
+        return league;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Team that = (Team) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.league, that.league);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, league);
+    }
+
+    @Override
+    public String toString() {
+        return "Team[" +
+                "name=" + name + ", " +
+                "league=" + league + ']';
+    }
+
 }

--- a/client/src/test/resources/client_init.json
+++ b/client/src/test/resources/client_init.json
@@ -1,0 +1,16 @@
+[{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "firstName": "Steven",
+    "lastName": "Stamkos",
+    "team": {
+      "name": "Tampa Bay Lightning",
+      "league": "NHL"
+    },
+    "number": 91,
+    "position": "C",
+    "birthDate": "1990-02-07T00:00:00.000+00:00",
+    "capHit": 7.5
+  }
+}]

--- a/client/src/test/resources/testBadVersion.json
+++ b/client/src/test/resources/testBadVersion.json
@@ -1,0 +1,16 @@
+[{
+  "jsonrpc": "1.0",
+  "id": 1,
+  "result": {
+    "firstName": "Steven",
+    "lastName": "Stamkos",
+    "team": {
+      "name": "Tampa Bay Lightning",
+      "league": "NHL"
+    },
+    "number": 91,
+    "position": "C",
+    "birthDate": "1990-02-07T00:00:00.000+00:00",
+    "capHit": 7.5
+  }
+}]

--- a/client/src/test/resources/testJsonRpcError.json
+++ b/client/src/test/resources/testJsonRpcError.json
@@ -1,0 +1,17 @@
+[{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "firstName": "Steven",
+    "lastName": "Stamkos",
+    "team": {
+      "name": "Tampa Bay Lightning",
+      "league": "NHL"
+    },
+    "number": 91,
+    "position": "C",
+    "birthDate": "1990-02-07T00:00:00.000+00:00",
+    "capHit": 7.5
+  }
+},
+  {"jsonrpc":"2.0","id":2, "error":{"code":-32603,"message":"Internal error"}}]

--- a/client/src/test/resources/testUnspecifiedId.json
+++ b/client/src/test/resources/testUnspecifiedId.json
@@ -1,0 +1,16 @@
+[{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "result": {
+    "firstName": "Steven",
+    "lastName": "Stamkos",
+    "team": {
+      "name": "Tampa Bay Lightning",
+      "league": "NHL"
+    },
+    "number": 91,
+    "position": "C",
+    "birthDate": "1990-02-07T00:00:00.000+00:00",
+    "capHit": 7.5
+  }
+}]

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>simple-json-rpc</artifactId>
         <groupId>com.github.arteam</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.001-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/ErrorMessage.java
+++ b/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/ErrorMessage.java
@@ -5,13 +5,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 /**
  * Date: 07.06.14
  * Time: 15:16
  * <p>Representation of a JSON-RPC error message</p>
  */
-public record ErrorMessage(@JsonProperty("code") int code, @JsonProperty("message") String message,
-                           @JsonProperty("data") @JsonInclude(JsonInclude.Include.NON_NULL) @Nullable JsonNode data) {
+public class ErrorMessage {
+    private int code;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private @Nullable JsonNode data;
+
+    public ErrorMessage(){}
 
     public ErrorMessage(@JsonProperty("code") int code,
                         @JsonProperty("message") String message,
@@ -21,21 +29,38 @@ public record ErrorMessage(@JsonProperty("code") int code, @JsonProperty("messag
         this.data = data;
     }
 
-    public int getCode() {
+    @Override public String toString() {
+        return "ErrorMessage{code=" + code + ", message=" + message + ", data=" + data + "}";
+    }
+
+    public int getCode() {return code;}
+    @JsonProperty("code") public int code() {
         return code;
     }
 
-    public String getMessage() {
+    public String getMessage() {return message;}
+    @JsonProperty("message") public String message() {
         return message;
     }
 
-    @Nullable
-    public JsonNode getData() {
+    @JsonProperty("data")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public @Nullable JsonNode data() {return data;}
+    @Nullable public JsonNode getData() {
         return data;
     }
 
-    @Override
-    public String toString() {
-        return "ErrorMessage{code=" + code + ", message=" + message + ", data=" + data + "}";
+    @Override public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ErrorMessage that = (ErrorMessage) obj;
+        return this.code == that.code &&
+                Objects.equals(this.message, that.message) &&
+                Objects.equals(this.data, that.data);
     }
+
+    @Override public int hashCode() {
+        return Objects.hash(code, message, data);
+    }
+
 }

--- a/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/ErrorResponse.java
+++ b/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/ErrorResponse.java
@@ -1,18 +1,36 @@
 package com.github.arteam.simplejsonrpc.core.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
+
+import java.util.Objects;
 
 /**
  * Date: 07.06.14
  * Time: 12:35
  * <p>Representation of a JSON-RPC error response</p>
  */
-public record ErrorResponse(ValueNode id,
-                            ErrorMessage error,
-                            String jsonrpc) implements Response {
+public class ErrorResponse implements Response {
 
-    public static final String VERSION = "2.0";
+    final public static String VERSION = "2.0";
+
+    private ValueNode id;
+    private ErrorMessage error;
+    private String jsonrpc;
+
+    public ErrorResponse(){}
+
+    /**
+     *
+     */
+    public ErrorResponse(ValueNode id,
+                         ErrorMessage error,
+                         String jsonrpc) {
+        this.id = id;
+        this.error = error;
+        this.jsonrpc = jsonrpc;
+    }
 
     public static ErrorResponse of(ErrorMessage error) {
         return new ErrorResponse(NullNode.getInstance(), error, VERSION);
@@ -21,4 +39,40 @@ public record ErrorResponse(ValueNode id,
     public static ErrorResponse of(ValueNode id, ErrorMessage error) {
         return new ErrorResponse(id, error, VERSION);
     }
+
+    @JsonProperty @Override public ValueNode id() {
+        return id;
+    }
+
+    @JsonProperty public ErrorMessage error() {
+        return error;
+    }
+
+    @JsonProperty @Override public String jsonrpc() {
+        return jsonrpc;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ErrorResponse that = (ErrorResponse) obj;
+        return Objects.equals(this.id, that.id) &&
+                Objects.equals(this.error, that.error) &&
+                Objects.equals(this.jsonrpc, that.jsonrpc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, error, jsonrpc);
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorResponse[" +
+                "id=" + id + ", " +
+                "error=" + error + ", " +
+                "jsonrpc=" + jsonrpc + ']';
+    }
+
 }

--- a/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/Request.java
+++ b/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/Request.java
@@ -1,25 +1,81 @@
 package com.github.arteam.simplejsonrpc.core.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * Date: 07.06.14
  * Time: 12:24
  * <p>Representation of a JSON-RPC request</p>
  */
-public record Request(@Nullable String jsonrpc, @Nullable String method,
-                      @Nullable JsonNode params,
-                      @Nullable ValueNode id) {
+public class Request {
+    private @Nullable String jsonrpc;
+    private @Nullable String method;
+    private @Nullable JsonNode params;
+    private @Nullable ValueNode id;
 
+    public Request(){}
+
+    /**
+     *
+     */
+    public Request(@Nullable String jsonrpc, @Nullable String method,
+                   @Nullable JsonNode params,
+                   @Nullable ValueNode id) {
+        this.jsonrpc = jsonrpc;
+        this.method = method;
+        this.params = params;
+        this.id = id;
+    }
+
+    @JsonProperty
     public ValueNode id() {
         return id != null ? id : NullNode.getInstance();
     }
 
+    @JsonProperty
     public JsonNode params() {
         return params != null ? params : NullNode.getInstance();
+    }
+
+    @JsonProperty
+    public @Nullable String jsonrpc() {
+        return jsonrpc;
+    }
+
+    @JsonProperty
+    public @Nullable String method() {
+        return method;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Request that = (Request) obj;
+        return Objects.equals(this.jsonrpc, that.jsonrpc) &&
+                Objects.equals(this.method, that.method) &&
+                Objects.equals(this.params, that.params) &&
+                Objects.equals(this.id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jsonrpc, method, params, id);
+    }
+
+    @Override
+    public String toString() {
+        return "Request[" +
+                "jsonrpc=" + jsonrpc + ", " +
+                "method=" + method + ", " +
+                "params=" + params + ", " +
+                "id=" + id + ']';
     }
 
 }

--- a/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/SuccessResponse.java
+++ b/core/src/main/java/com/github/arteam/simplejsonrpc/core/domain/SuccessResponse.java
@@ -1,15 +1,69 @@
 package com.github.arteam.simplejsonrpc.core.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * Date: 07.06.14
  * Time: 12:31
  * Representation of a successful JSON-RPC response
  */
-public record SuccessResponse(ValueNode id,
-                              @Nullable Object result,
-                              String jsonrpc) implements Response {
-    public static final String VERSION = "2.0";
+public class SuccessResponse implements Response {
+    final public static String VERSION = "2.0";
+
+    private ValueNode id;
+    private @Nullable Object result;
+    private String jsonrpc;
+
+    public SuccessResponse(){}
+
+    public SuccessResponse(ValueNode id,
+                           @Nullable Object result,
+                           String jsonrpc) {
+        this.id = id;
+        this.result = result;
+        this.jsonrpc = jsonrpc;
+    }
+
+    @JsonProperty @Override
+    public ValueNode id() {
+        return id;
+    }
+
+    @JsonProperty
+    public @Nullable Object result() {
+        return result;
+    }
+
+    @JsonProperty @Override
+    public String jsonrpc() {
+        return jsonrpc;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        SuccessResponse that = (SuccessResponse) obj;
+        return Objects.equals(this.id, that.id) &&
+                Objects.equals(this.result, that.result) &&
+                Objects.equals(this.jsonrpc, that.jsonrpc);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, result, jsonrpc);
+    }
+
+    @Override
+    public String toString() {
+        return "SuccessResponse[" +
+                "id=" + id + ", " +
+                "result=" + result + ", " +
+                "jsonrpc=" + jsonrpc + ']';
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.arteam</groupId>
     <artifactId>simple-json-rpc</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4.001-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>simple-json-rpc</name>
@@ -61,8 +61,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
                     <configuration>
-                        <source>17</source>
-                        <target>17</target>
+                        <source>10</source>
+                        <target>10</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>simple-json-rpc</artifactId>
         <groupId>com.github.arteam</groupId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.4.001-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/server/src/main/java/com/github/arteam/simplejsonrpc/server/JsonRpcServer.java
+++ b/server/src/main/java/com/github/arteam/simplejsonrpc/server/JsonRpcServer.java
@@ -156,10 +156,11 @@ public class JsonRpcServer {
         if (requestNode.get("id") == null) {
             if (response instanceof SuccessResponse) {
                 return true;
-            } else if (response instanceof ErrorResponse errorResponse) {
+            } else if (response instanceof ErrorResponse) {
                 // Notification request should be a valid JSON-RPC request.
                 // So if we get "Parse error" or "Invalid request"
                 // we can't consider the request as a notification
+                ErrorResponse errorResponse = (ErrorResponse)response;
                 int errorCode = errorResponse.error().getCode();
                 if (errorCode != PARSE_ERROR.getCode() && errorCode != INVALID_REQUEST.getCode()) {
                     return true;

--- a/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/ClassMetadata.java
+++ b/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/ClassMetadata.java
@@ -1,6 +1,7 @@
 package com.github.arteam.simplejsonrpc.server.metadata;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Date: 8/1/14
@@ -8,6 +9,46 @@ import java.util.Map;
  * <p>
  * Metadata about a Java class
  */
-public record ClassMetadata(boolean service,
-                            Map<String, MethodMetadata> methods) {
+public final class ClassMetadata {
+    private final boolean service;
+    private final Map<String, MethodMetadata> methods;
+
+    /**
+     *
+     */
+    public ClassMetadata(boolean service,
+                         Map<String, MethodMetadata> methods) {
+        this.service = service;
+        this.methods = methods;
+    }
+
+    public boolean service() {
+        return service;
+    }
+
+    public Map<String, MethodMetadata> methods() {
+        return methods;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (ClassMetadata) obj;
+        return this.service == that.service &&
+                Objects.equals(this.methods, that.methods);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(service, methods);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassMetadata[" +
+                "service=" + service + ", " +
+                "methods=" + methods + ']';
+    }
+
 }

--- a/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/MethodMetadata.java
+++ b/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/MethodMetadata.java
@@ -2,6 +2,7 @@ package com.github.arteam.simplejsonrpc.server.metadata;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Date: 8/1/14
@@ -9,6 +10,54 @@ import java.util.Map;
  * <p>
  * Metadata about a Java method
  */
-public record MethodMetadata(String name, MethodHandle methodHandle,
-                             Map<String, ParameterMetadata> params) {
+public final class MethodMetadata {
+    private final String name;
+    private final MethodHandle methodHandle;
+    private final Map<String, ParameterMetadata> params;
+
+    /**
+     *
+     */
+    public MethodMetadata(String name, MethodHandle methodHandle,
+                          Map<String, ParameterMetadata> params) {
+        this.name = name;
+        this.methodHandle = methodHandle;
+        this.params = params;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public MethodHandle methodHandle() {
+        return methodHandle;
+    }
+
+    public Map<String, ParameterMetadata> params() {
+        return params;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (MethodMetadata) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.methodHandle, that.methodHandle) &&
+                Objects.equals(this.params, that.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, methodHandle, params);
+    }
+
+    @Override
+    public String toString() {
+        return "MethodMetadata[" +
+                "name=" + name + ", " +
+                "methodHandle=" + methodHandle + ", " +
+                "params=" + params + ']';
+    }
+
 }

--- a/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/ParameterMetadata.java
+++ b/server/src/main/java/com/github/arteam/simplejsonrpc/server/metadata/ParameterMetadata.java
@@ -1,6 +1,7 @@
 package com.github.arteam.simplejsonrpc.server.metadata;
 
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 /**
  * Date: 8/1/14
@@ -8,6 +9,70 @@ import java.lang.reflect.Type;
  * <p>
  * Method parameter metadata
  */
-public record ParameterMetadata(String name, Class<?> type, Type genericType,
-                                int index, boolean optional) {
+public class ParameterMetadata {
+    private String name;
+    private Class<?> type;
+    private Type genericType;
+    private int index;
+    private boolean optional;
+
+    /**
+     *
+     */
+    public ParameterMetadata(String name, Class<?> type, Type genericType,
+                             int index, boolean optional) {
+        this.name = name;
+        this.type = type;
+        this.genericType = genericType;
+        this.index = index;
+        this.optional = optional;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Class<?> type() {
+        return type;
+    }
+
+    public Type genericType() {
+        return genericType;
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public boolean optional() {
+        return optional;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (ParameterMetadata) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.type, that.type) &&
+                Objects.equals(this.genericType, that.genericType) &&
+                this.index == that.index &&
+                this.optional == that.optional;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type, genericType, index, optional);
+    }
+
+    @Override
+    public String toString() {
+        return "ParameterMetadata[" +
+                "name=" + name + ", " +
+                "type=" + type + ", " +
+                "genericType=" + genericType + ", " +
+                "index=" + index + ", " +
+                "optional=" + optional + ']';
+    }
+
 }

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/domain/Player.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/domain/Player.java
@@ -1,13 +1,105 @@
 package com.github.arteam.simplejsonrpc.server.simple.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Date: 7/29/14
  * Time: 12:49 PM
  */
-public record Player(String firstName, String lastName,
-                     Team team, int number,
-                     Position position, Date birthDate,
-                     double capHit) {
+public class Player {
+    private String firstName;
+    private String lastName;
+    private Team team;
+    private int number;
+    private Position position;
+    private Date birthDate;
+    private double capHit;
+
+    /**
+     *
+     */
+    public Player(){}
+
+    public Player(String firstName, String lastName,
+                  Team team, int number,
+                  Position position, Date birthDate,
+                  double capHit) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.team = team;
+        this.number = number;
+        this.position = position;
+        this.birthDate = birthDate;
+        this.capHit = capHit;
+    }
+
+    @JsonProperty("firstName")
+    public String firstName() {
+        return firstName;
+    }
+
+    @JsonProperty("lastName")
+    public String lastName() {
+        return lastName;
+    }
+
+    @JsonProperty("team")
+    public Team team() {
+        return team;
+    }
+
+    @JsonProperty("number")
+    public int number() {
+        return number;
+    }
+
+    @JsonProperty("position")
+    public Position position() {
+        return position;
+    }
+
+    @JsonProperty("birthDate")
+    public Date birthDate() {
+        return birthDate;
+    }
+
+    @JsonProperty("capHit")
+    public double capHit() {
+        return capHit;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Player) obj;
+        return Objects.equals(this.firstName, that.firstName) &&
+                Objects.equals(this.lastName, that.lastName) &&
+                Objects.equals(this.team, that.team) &&
+                this.number == that.number &&
+                Objects.equals(this.position, that.position) &&
+                Objects.equals(this.birthDate, that.birthDate) &&
+                Double.doubleToLongBits(this.capHit) == Double.doubleToLongBits(that.capHit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, team, number, position, birthDate, capHit);
+    }
+
+    @Override
+    public String toString() {
+        return "Player[" +
+                "firstName=" + firstName + ", " +
+                "lastName=" + lastName + ", " +
+                "team=" + team + ", " +
+                "number=" + number + ", " +
+                "position=" + position + ", " +
+                "birthDate=" + birthDate + ", " +
+                "capHit=" + capHit + ']';
+    }
+
 }

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/domain/Team.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/domain/Team.java
@@ -1,8 +1,57 @@
 package com.github.arteam.simplejsonrpc.server.simple.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
 /**
  * Date: 7/29/14
  * Time: 2:07 PM
  */
-public record Team(String name, String league) {
+public class Team {
+
+    private String name;
+    private String league;
+
+    public Team(){}
+
+    /**
+     *
+     */
+    public Team(String name, String league) {
+        this.name = name;
+        this.league = league;
+    }
+
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    @JsonProperty
+    public String league() {
+        return league;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Team) obj;
+        return Objects.equals(this.name, that.name) &&
+                Objects.equals(this.league, that.league);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, league);
+    }
+
+    @Override
+    public String toString() {
+        return "Team[" +
+                "name=" + name + ", " +
+                "league=" + league + ']';
+    }
+
 }

--- a/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/util/RequestResponse.java
+++ b/server/src/test/java/com/github/arteam/simplejsonrpc/server/simple/util/RequestResponse.java
@@ -1,10 +1,54 @@
 package com.github.arteam.simplejsonrpc.server.simple.util;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Objects;
 
 /**
  * Date: 7/28/14
  * Time: 11:26 PM
  */
-public record RequestResponse(JsonNode request, JsonNode response) {
+public class RequestResponse {
+    private JsonNode request;
+    private JsonNode response;
+
+    public RequestResponse(){}
+
+    public RequestResponse(JsonNode request, JsonNode response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    @JsonProperty
+    public JsonNode request() {
+        return request;
+    }
+
+    @JsonProperty
+    public JsonNode response() {
+        return response;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (RequestResponse) obj;
+        return Objects.equals(this.request, that.request) &&
+                Objects.equals(this.response, that.response);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(request, response);
+    }
+
+    @Override
+    public String toString() {
+        return "RequestResponse[" +
+                "request=" + request + ", " +
+                "response=" + response + ']';
+    }
+
 }


### PR DESCRIPTION
The JSON-RPC v1.0 responses are very similar to v2.0. The jsonrpc field was added to responses of the second version of the protocol. In the first version of the protocol, this field is optional and may absent.

In fact, this pool-request allows the simple-json-rpc library to accept responses in jsonrpc 1.0 format; See RequestBuilder class. I have verified work-ability by tests;

After this I done the first enhancement, I attempted to deploy a project with the simple-json-rpc library and found out that there are dependencies that are not compatible with the latest Java versions. So then I looked through the code of the simple-json-rpc lib and found out that the core of the library is not using Java 17 itself. A major things using the latest Java language features is Tests and connected with them DTO objects there. So, I rewrote the records in POJO manner, verified all tests are passing and that is it! Library is compatible with java 10+ now;

Tadam! The pool request make it possible to import simple-json-rpc in a larger number of projects.